### PR TITLE
network operator: allow tolerations for `ulimit-fixer`

### DIFF
--- a/nvidia-network-operator/chart/Chart.yaml
+++ b/nvidia-network-operator/chart/Chart.yaml
@@ -19,4 +19,4 @@ name: network-operator
 sources:
 - https://github.com/Mellanox/network-operator
 type: application
-version: 24.4.0
+version: 24.4.1

--- a/nvidia-network-operator/chart/templates/ulimit-fixer.yaml
+++ b/nvidia-network-operator/chart/templates/ulimit-fixer.yaml
@@ -24,3 +24,7 @@ spec:
             ]
           securityContext:
             privileged: true
+    {{- with .Values.nebius.ulimitFixer.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/nvidia-network-operator/chart/values.yaml
+++ b/nvidia-network-operator/chart/values.yaml
@@ -18,6 +18,11 @@
 nebius:
   images:
     ulimitFixer: cr.eu-north1.nebius.cloud/e00vzg8t0148cc4zex/nebius/network-operator-v24-4-0/busybox:1.27.2
+  ulimitFixer:
+    tolerations:
+  #   - key: nvidia.com/gpu
+  #     operator: Exists
+  #     effect: NoSchedule
 
 nfd:
   enabled: false


### PR DESCRIPTION
This PR allows configuration of tolerations for the `ulimit-fixer` Daemonset.