### PR TITLE
Optimized resources for Grafana instance

### DIFF
--- a/nebius-grafana/chart/charts/grafana/values.yaml
+++ b/nebius-grafana/chart/charts/grafana/values.yaml
@@ -350,13 +350,13 @@ route:
     ## Additional custom rules that can be added to the route
     additionalRules: []
 
-resources: {}
-#  limits:
-#    cpu: 100m
-#    memory: 128Mi
-#  requests:
-#    cpu: 100m
-#    memory: 128Mi
+resources:
+  requests:
+    cpu: "2"
+    memory: "4Gi"
+  limits:
+    cpu: "2"
+    memory: "4Gi"
 
 ## Node labels for pod assignment
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/


### PR DESCRIPTION
By default this helm creates Grafana instance with 8 CPUs and 32 Gigs of RAM. This is too much for Grafana, so I specified reasonable limits explicitly.