### PR TITLE
nebius grafana: add storage

### DIFF
--- a/nebius-grafana/chart/values.yaml
+++ b/nebius-grafana/chart/values.yaml
@@ -3,6 +3,14 @@ grafana:
     projectId: REPLACE WITH PROJECT ID
     accessToken: REPLACE WITH ACCESS TOKEN
 
+  persistence:
+    type: pvc
+    enabled: true
+    storageClassName: compute-csi-default-sc
+    accessModes:
+      - ReadWriteOnce
+    size: 10Gi
+
   resources:
     requests: # https://grafana.com/docs/grafana/latest/setup-grafana/installation/kubernetes/#minimum-hardware-requirements
       cpu: 250m

--- a/nebius-grafana/chart/values.yaml
+++ b/nebius-grafana/chart/values.yaml
@@ -4,11 +4,8 @@ grafana:
     accessToken: REPLACE WITH ACCESS TOKEN
 
   persistence:
-    type: pvc
     enabled: true
     storageClassName: compute-csi-default-sc
-    accessModes:
-      - ReadWriteOnce
     size: 10Gi
 
   resources:

--- a/nebius-grafana/chart/values.yaml
+++ b/nebius-grafana/chart/values.yaml
@@ -4,7 +4,7 @@ grafana:
     accessToken: REPLACE WITH ACCESS TOKEN
 
   resources:
-    requests:  # https://grafana.com/docs/grafana/latest/setup-grafana/installation/kubernetes/#minimum-hardware-requirements
+    requests: # https://grafana.com/docs/grafana/latest/setup-grafana/installation/kubernetes/#minimum-hardware-requirements
       cpu: 250m
       memory: 750Mi
 

--- a/nebius-grafana/chart/values.yaml
+++ b/nebius-grafana/chart/values.yaml
@@ -5,7 +5,6 @@ grafana:
 
   persistence:
     enabled: true
-    storageClassName: compute-csi-default-sc
     size: 10Gi
 
   resources:


### PR DESCRIPTION
Add storage to Nebius Grafana to help store all created dashboards, even after pods are reloaded.

`compute-csi-default-sc` is available by [default](https://docs.nebius.com/kubernetes/storage/disk-over-csi#storage-class).
