### PR TITLE
Add Voxel51 FiftyOne marketplace app

### DIFF
--- a/voxel51-fiftyone/README.md
+++ b/voxel51-fiftyone/README.md
@@ -1,0 +1,61 @@
+# FiftyOne
+
+## Description
+
+FiftyOne is an open source tool from Voxel51 for building, curating, visualizing, and evaluating computer vision datasets and models. This application deploys the FiftyOne App server on Nebius Managed Service for Kubernetes so users can inspect datasets through a browser.
+
+The deployment runs the FiftyOne server on port `5151`, runs a colocated MongoDB container for FiftyOne metadata, and stores MongoDB data, default datasets, dataset zoo cache, and model zoo cache on a persistent volume.
+
+## Short description
+
+Deploy the Voxel51 FiftyOne App for visual AI dataset exploration and model evaluation.
+
+## Tutorial
+
+Before installing, make sure your Nebius Managed Service for Kubernetes cluster has enough persistent storage for the datasets you plan to load. The default persistent volume size is `128Gi`.
+
+During installation:
+
+1. Select the target Kubernetes cluster.
+2. Choose the application name and namespace.
+3. Set the persistent volume size.
+4. Install the application.
+
+The application uses the upstream Voxel51 FiftyOne image and the upstream MongoDB image, both pinned to concrete tags.
+
+## Usage
+
+After installation, forward the FiftyOne service to your workstation:
+
+```bash
+kubectl --namespace <namespace> port-forward service/<release-name> 5151:5151
+```
+
+Open `http://127.0.0.1:5151` in your browser.
+
+To load a sample dataset into the running pod:
+
+```bash
+kubectl --namespace <namespace> get pods -l app.kubernetes.io/name=fiftyone
+kubectl --namespace <namespace> exec -it <pod-name> -- python -c "import fiftyone as fo, fiftyone.zoo as foz; foz.load_zoo_dataset('quickstart', dataset_name='quickstart', persistent=True)"
+```
+
+Refresh the browser after the dataset import completes.
+
+## Use cases
+
+- Inspect images, videos, labels, predictions, and embeddings in the FiftyOne App.
+- Curate visual datasets before model training.
+- Analyze model predictions and failure modes.
+- Load public zoo datasets or persistent datasets into a shared Kubernetes environment.
+
+## Links
+
+- [FiftyOne documentation](https://docs.voxel51.com/)
+- [FiftyOne source code](https://github.com/voxel51/fiftyone)
+- [FiftyOne Dockerfile](https://github.com/voxel51/fiftyone/blob/develop/Dockerfile)
+- [Voxel51 website](https://voxel51.com/)
+
+## Legal
+
+FiftyOne is distributed under the [Apache License 2.0](https://github.com/voxel51/fiftyone/blob/develop/LICENSE). By using this application, you are responsible for complying with the licenses and terms that apply to FiftyOne, its dependencies, and any datasets or models you load into the application.

--- a/voxel51-fiftyone/chart/Chart.yaml
+++ b/voxel51-fiftyone/chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: fiftyone
+description: A Helm chart for deploying Voxel51 FiftyOne on Nebius AI
+type: application
+version: 1.15.0
+appVersion: "1.15.0"

--- a/voxel51-fiftyone/chart/templates/NOTES.txt
+++ b/voxel51-fiftyone/chart/templates/NOTES.txt
@@ -1,0 +1,9 @@
+FiftyOne has been deployed.
+
+Run this command to open the app locally:
+
+  kubectl --namespace {{ .Release.Namespace }} port-forward service/{{ include "fiftyone.fullname" . }} 5151:{{ .Values.fiftyone.service.port }}
+
+Then visit:
+
+  http://127.0.0.1:5151

--- a/voxel51-fiftyone/chart/templates/_helpers.tpl
+++ b/voxel51-fiftyone/chart/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fiftyone.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "fiftyone.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "fiftyone.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "fiftyone.labels" -}}
+helm.sh/chart: {{ include "fiftyone.chart" . }}
+{{ include "fiftyone.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "fiftyone.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "fiftyone.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "fiftyone.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "fiftyone.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/voxel51-fiftyone/chart/templates/deployment.yaml
+++ b/voxel51-fiftyone/chart/templates/deployment.yaml
@@ -1,0 +1,131 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "fiftyone.fullname" . }}
+  labels:
+    {{- include "fiftyone.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.fiftyone.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "fiftyone.selectorLabels" . | nindent 6 }}
+  {{- with .Values.fiftyone.updateStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "fiftyone.selectorLabels" . | nindent 8 }}
+        {{- with .Values.fiftyone.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.fiftyone.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "fiftyone.serviceAccountName" . }}
+      {{- with .Values.fiftyone.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.fiftyone.podSecurityContext | nindent 8 }}
+      {{- with .Values.fiftyone.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.fiftyone.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.fiftyone.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: fiftyone
+          securityContext:
+            {{- toYaml .Values.fiftyone.securityContext | nindent 12 }}
+          image: "{{ .Values.fiftyone.image.repository }}:{{ .Values.fiftyone.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.fiftyone.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -ec
+          args:
+            - |
+              until python - <<'PY'
+              import pymongo
+              import sys
+
+              try:
+                  pymongo.MongoClient("mongodb://127.0.0.1:{{ .Values.mongodb.port }}", serverSelectionTimeoutMS=1000).admin.command("ping")
+              except Exception:
+                  sys.exit(1)
+              PY
+              do
+                sleep 2
+              done
+              exec python -m fiftyone.server.main --port {{ .Values.fiftyone.service.port }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.fiftyone.service.port }}
+              protocol: TCP
+          env:
+            - name: FIFTYONE_DATABASE_URI
+              value: {{ printf "mongodb://127.0.0.1:%v" .Values.mongodb.port | quote }}
+            - name: FIFTYONE_DATABASE_DIR
+              value: {{ printf "%s/db" .Values.fiftyone.storage.mountPath | quote }}
+            - name: FIFTYONE_DEFAULT_APP_ADDRESS
+              value: "0.0.0.0"
+            - name: FIFTYONE_DEFAULT_DATASET_DIR
+              value: {{ printf "%s/default" .Values.fiftyone.storage.mountPath | quote }}
+            - name: FIFTYONE_DATASET_ZOO_DIR
+              value: {{ printf "%s/zoo/datasets" .Values.fiftyone.storage.mountPath | quote }}
+            - name: FIFTYONE_MODEL_ZOO_DIR
+              value: {{ printf "%s/zoo/models" .Values.fiftyone.storage.mountPath | quote }}
+            {{- range $name, $value := .Values.fiftyone.extraEnv }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- with .Values.fiftyone.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.fiftyone.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.fiftyone.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.fiftyone.resources | nindent 12 }}
+          volumeMounts:
+            - name: fiftyone-data
+              mountPath: {{ .Values.fiftyone.storage.mountPath }}
+              subPath: fiftyone
+        - name: mongodb
+          securityContext:
+            {{- toYaml .Values.mongodb.securityContext | nindent 12 }}
+          image: "{{ .Values.mongodb.image.repository }}:{{ .Values.mongodb.image.tag }}"
+          imagePullPolicy: {{ .Values.mongodb.image.pullPolicy }}
+          args:
+            - --bind_ip
+            - 127.0.0.1
+          ports:
+            - name: mongodb
+              containerPort: {{ .Values.mongodb.port }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.mongodb.resources | nindent 12 }}
+          volumeMounts:
+            - name: fiftyone-data
+              mountPath: {{ .Values.mongodb.storage.mountPath }}
+              subPath: mongodb
+      volumes:
+        - name: fiftyone-data
+          persistentVolumeClaim:
+            claimName: {{ include "fiftyone.fullname" . }}-data

--- a/voxel51-fiftyone/chart/templates/pvc.yaml
+++ b/voxel51-fiftyone/chart/templates/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "fiftyone.fullname" . }}-data
+  labels:
+    {{- include "fiftyone.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.fiftyone.storage.size | quote }}

--- a/voxel51-fiftyone/chart/templates/service.yaml
+++ b/voxel51-fiftyone/chart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fiftyone.fullname" . }}
+  labels:
+    {{- include "fiftyone.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.fiftyone.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.fiftyone.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "fiftyone.selectorLabels" . | nindent 4 }}

--- a/voxel51-fiftyone/chart/templates/serviceaccount.yaml
+++ b/voxel51-fiftyone/chart/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "fiftyone.serviceAccountName" . }}
+  labels:
+    {{- include "fiftyone.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/voxel51-fiftyone/chart/values.yaml
+++ b/voxel51-fiftyone/chart/values.yaml
@@ -1,0 +1,116 @@
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  automount: true
+  annotations: {}
+  name: ""
+
+fiftyone:
+  replicaCount: 1
+
+  image:
+    repository: voxel51/fiftyone
+    tag: "1.15.0"
+    pullPolicy: IfNotPresent
+
+  imagePullSecrets: []
+
+  storage:
+    size: 128Gi
+    mountPath: /fiftyone
+
+  service:
+    type: ClusterIP
+    port: 5151
+
+  updateStrategy:
+    type: Recreate
+
+  podAnnotations: {}
+  podLabels: {}
+
+  podSecurityContext:
+    fsGroup: 1000
+
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: "4"
+      memory: 8Gi
+
+  startupProbe:
+    httpGet:
+      path: /
+      port: http
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 30
+
+  livenessProbe:
+    httpGet:
+      path: /
+      port: http
+    initialDelaySeconds: 30
+    periodSeconds: 20
+    timeoutSeconds: 5
+    failureThreshold: 6
+
+  readinessProbe:
+    httpGet:
+      path: /
+      port: http
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+
+  extraEnv: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+mongodb:
+  image:
+    repository: mongo
+    tag: "7.0.15"
+    pullPolicy: IfNotPresent
+
+  port: 27017
+
+  storage:
+    mountPath: /data/db
+
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      add:
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - SETGID
+        - SETUID
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "2"
+      memory: 2Gi

--- a/voxel51-fiftyone/icon.svg
+++ b/voxel51-fiftyone/icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title desc">
+  <title id="title">FiftyOne</title>
+  <desc id="desc">Original FiftyOne marketplace icon with the number 51.</desc>
+  <rect width="128" height="128" rx="24" fill="#101828"/>
+  <circle cx="94" cy="34" r="18" fill="#43D7A7"/>
+  <path d="M25 30h48v16H42v18h27v16H42v32H25V30z" fill="#FFFFFF"/>
+  <path d="M86 61h15v51H84V80l-10 6-8-13 20-12z" fill="#FFFFFF"/>
+</svg>

--- a/voxel51-fiftyone/manifest.yaml
+++ b/voxel51-fiftyone/manifest.yaml
@@ -1,0 +1,14 @@
+slug: fiftyone
+ownerName: Voxel51
+publisherName: Nebius
+name: FiftyOne
+categories:
+  - dataset-preparation
+  - ml-ai
+tariff_type: free
+
+images:
+  - nameWithRegistry: fiftyone.image.repository
+    tag: fiftyone.image.tag
+  - nameWithRegistry: mongodb.image.repository
+    tag: mongodb.image.tag

--- a/voxel51-fiftyone/values.form.json
+++ b/voxel51-fiftyone/values.form.json
@@ -1,0 +1,109 @@
+{
+  "type": "object",
+  "required": true,
+  "viewSpec": {
+    "type": "base",
+    "order": [
+      "mk8sCluster",
+      "general",
+      "fiftyone"
+    ],
+    "layout": ""
+  },
+  "defaultValue": {
+    "fiftyone": {
+      "storage": {
+        "size": "128Gi"
+      }
+    }
+  },
+  "properties": {
+    "mk8sCluster": {
+      "type": "object",
+      "required": true,
+      "viewSpec": {
+        "type": "mk8s_cluster"
+      }
+    },
+    "general": {
+      "type": "object",
+      "viewSpec": {
+        "type": "base",
+        "layout": "section",
+        "layoutTitle": "General"
+      },
+      "defaultValue": {},
+      "properties": {
+        "appname": {
+          "type": "string",
+          "required": true,
+          "viewSpec": {
+            "type": "base",
+            "layout": "row",
+            "layoutTitle": "Application name"
+          },
+          "defaultValue": "fiftyone"
+        },
+        "namespace": {
+          "type": "string",
+          "required": true,
+          "viewSpec": {
+            "type": "base",
+            "layout": "row",
+            "layoutTitle": "Namespace"
+          },
+          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+          "patternError": "namespace must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+          "defaultValue": "fiftyone"
+        }
+      }
+    },
+    "fiftyone": {
+      "type": "object",
+      "viewSpec": {
+        "type": "base",
+        "order": [
+          "storage"
+        ],
+        "layout": ""
+      },
+      "defaultValue": {
+        "storage": {
+          "size": "128Gi"
+        }
+      },
+      "properties": {
+        "storage": {
+          "type": "object",
+          "viewSpec": {
+            "type": "base",
+            "order": [
+              "size"
+            ],
+            "layout": ""
+          },
+          "defaultValue": {
+            "size": "128Gi"
+          },
+          "properties": {
+            "size": {
+              "type": "string",
+              "viewSpec": {
+                "disabled": false,
+                "inputProps": {
+                  "max": 2048,
+                  "min": 10,
+                  "suffix": "Gi"
+                },
+                "layout": "row",
+                "layoutDescription": "Persistent storage for FiftyOne database files, datasets, model zoo cache, and dataset zoo cache.",
+                "layoutTitle": "Persistent volume size in GB",
+                "type": "rangeinputpicker"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add a Voxel51 FiftyOne marketplace app package
- Deploy FiftyOne with upstream voxel51/fiftyone:1.15.0 and a colocated mongo:7.0.15 sidecar
- Add marketplace metadata, installation form, README, icon, and Helm chart resources

## Validation
- Marketplace checker passed
- helm lint passed
- helm template rendered
- Live install tested on nebius-mk8s-test1-osmo-pro-cluster in namespace fiftyone
- Final release reached 2/2 Running and HTTP probe returned 200 through port-forward